### PR TITLE
Fix overcrowded tabs and move tabs to top of the page

### DIFF
--- a/assets/css/geoContrast.css
+++ b/assets/css/geoContrast.css
@@ -60,9 +60,9 @@ Karim Bahgat
 }
 
 .toolbox {
-    padding-left: 2px;
+    padding-left: 0px;
     margin-top: 0px;
-    margin-left: 2px;
+    margin-left: 0px;
     height:600px;
 }
 

--- a/assets/css/geoContrastCountries.css
+++ b/assets/css/geoContrastCountries.css
@@ -60,9 +60,9 @@ Karim Bahgat
 }
 
 .toolbox {
-    padding-left: 2px;
+    padding-left: 0px;
     margin-top: 0px;
-    margin-left: 2px;
+    margin-left: 0px;
     height:600px;
 }
 

--- a/geoContrast.html
+++ b/geoContrast.html
@@ -75,6 +75,13 @@
 					</header>
 
 					<div id="map-and-toolbox-div" class="row" style="width:100%; margin-left:0; margin-bottom:25px">
+
+						<ul class='etabs' style="display:flex; flex-direction:row; width:100%">
+							<li class='tab'><a href="geoContrastCountries.html">Global Boundaries</a></li>
+							<li class='tab active'><a href="geoContrast.html">Country Boundaries</a></li>
+							<li class='tab'><a href="geoData.html">Country Data</a></li>
+						</ul>
+
 						<div class="col-7 col-12-medium" style="padding-left:0">
 							<div id="fullscreen" class="fullscreen">
 								<div id="map" class="map">
@@ -110,19 +117,13 @@
 								</div>
 							</div>
 						</div>
+
 						<div class="col-5 col-12-medium" style="padding:0; ">
 							<div id="toolbox" class="toolbox">
 								
 								<div id="tab-container" class="tab-container">
-								
-								
-									<ul class='etabs'>
-										<li class='tab'><a href="geoContrastCountries.html">Global Boundaries</a></li>
-										<li class='tab active'><a href="geoContrast.html">Country Boundaries</a></li>
-										<!--<li class='tab'><a href="geoData.html">Country Data</a></li>-->
-									</ul>
 
-									<div id="compare" class="box" style="font-size:14pt; height:575px">
+									<div id="compare" class="box" style="font-size:14pt; height:600px">
 									
 										<div id="compare-main" style="height:50%">
 											<hr style="border-color:#319FD3; background-color:#319FD3; margin:3px; height:3px">

--- a/geoContrastCountries.html
+++ b/geoContrastCountries.html
@@ -76,26 +76,27 @@
 						<span><h1>Visualize & Compare Boundaries</h1></span>
 					</header>
 
-					<div id="map-and-toolbox-div" class="row gtr-200" style="width:100%; margin-left:0; margin-bottom:25px">
+					<div id="map-and-toolbox-div" class="row" style="width:100%; margin-left:0; margin-bottom:25px">
+
+						<ul class='etabs' style="display:flex; flex-direction:row; width:100%">
+							<li class='tab active'><a href="geoContrastCountries.html">Global Boundaries</a></li>
+							<li class='tab'><a href="geoContrast.html">Country Boundaries</a></li>
+							<li class='tab'><a href="geoData.html">Country Data</a></li>
+						</ul>
+
 						<div class="col-7 col-12-medium" style="padding-left:0">
 							<div id="fullscreen" class="fullscreen">
 								<div id="map" class="map">
 								</div>
 							</div>
 						</div>
+
 						<div class="col-5 col-12-medium" style="padding:0; ">
 							<div id="toolbox" class="toolbox">
 								
 								<div id="tab-container" class="tab-container">
-								
-								
-									<ul class='etabs'>
-										<li class='tab active'><a href="geoContrastCountries.html">Global Boundaries</a></li>
-										<li class='tab'><a href="geoContrast.html">Country Boundaries</a></li>
-										<!--<li class='tab'><a href="geoData.html">Country Data</a></li>-->
-									</ul>
 									
-									<div id="countries" class="box" style="font-size:14pt; height:575px">
+									<div id="countries" class="box" style="font-size:14pt; height:600px">
 									
                                         <div style="padding:15px">
 

--- a/geoData.html
+++ b/geoData.html
@@ -78,26 +78,27 @@
 						<span><h1>Visualize & Compare Boundaries</h1></span>
 					</header>
 
-					<div id="map-and-toolbox-div" class="row gtr-200" style="width:100%; margin-left:0; margin-bottom:25px">
+					<div id="map-and-toolbox-div" class="row" style="width:100%; margin-left:0; margin-bottom:25px">
+
+						<ul class='etabs' style="display:flex; flex-direction:row; width:100%">
+							<li class='tab'><a href="geoContrastCountries.html">Global Boundaries</a></li>
+							<li class='tab'><a href="geoContrast.html">Country Boundaries</a></li>
+							<li class='tab active'><a href="geoData.html">Country Data</a></li>
+						</ul>
+						
 						<div class="col-7 col-12-medium" style="padding-left:0">
 							<div id="fullscreen" class="fullscreen">
 								<div id="map" class="map" style="height:725px">
 								</div>
 							</div>
 						</div>
+
 						<div class="col-5 col-12-medium" style="padding:0; ">
 							<div id="toolbox" class="toolbox">
 								
 								<div id="tab-container" class="tab-container">
-								
-								
-									<ul class='etabs'>
-										<li class='tab'><a href="geoContrastCountries.html">Global Boundaries</a></li>
-										<li class='tab'><a href="geoContrast.html">Country Boundaries</a></li>
-										<li class='tab active'><a href="geoData.html">Country Data</a></li>
-									</ul>
 									
-									<div id="countries" class="box" style="font-size:14pt; height:700px">
+									<div id="countries" class="box" style="font-size:14pt; height:725px">
 									  <div style="padding:0px">
 
 									    <div class="row" style="margin-top:0px">


### PR DESCRIPTION
Now that we added a new "Country Data" tab, on smaller devices (including my laptop) the list of tab buttons gets too crowded and wraps downwards which looks weird (see pics below) and pushes the toolbox out of line with the map on the bottom (not shown in pics). In addition, on mobile the old tabs were placed below the map, so you had to scroll down to switch between the different visualization pages. 

Laptop:
![image](https://user-images.githubusercontent.com/6413369/156937159-40d9054e-6442-491a-95b9-72f0dc49cf5d.png)

Mobile:
![image](https://user-images.githubusercontent.com/6413369/156937181-54c7faa8-fe2e-4222-a59d-e9174583c2b3.png)

It's not perfect and we may need to think through a better approach for navigating the different pages, but this PR introduces a temporary solution by moving the tabs to above the map and makes sure the tabs are shown as a single row that don't wrap (see pics below). 

Laptop:
![image](https://user-images.githubusercontent.com/6413369/156937196-04bda7d0-613e-462d-a2ec-ccfc178f9908.png)
Mobile:
![image](https://user-images.githubusercontent.com/6413369/156937211-5e145a1a-0c8b-40ba-a611-b36f40ce63bb.png)
